### PR TITLE
fix(sign): use extra entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let tx = Tx.create({ sign: sign });
 let Secp256k1 = require("@dashincubator/secp256k1");
 
 async function sign({ privateKey, hash }) {
-  let sigOpts = { canonical: true };
+  let sigOpts = { canonical: true, extraEntropy: true };
   let sigBuf = await Secp256k1.sign(hash, privateKey, sigOpts);
   return Tx.utils.u8ToHex(sigBuf);
 }
@@ -63,7 +63,7 @@ Note: You must provide your own `sign()` function, as shown below.
   let Secp256k1 = window.nobleSecp256k1;
 
   async function sign({ privateKey, hash }) {
-    let sigOpts = { canonical: true };
+    let sigOpts = { canonical: true, extraEntropy: true };
     let sigBuf = await Secp256k1.sign(hash, privateKey, sigOpts);
     return Tx.utils.u8ToHex(sigBuf);
   }

--- a/dashtx.js
+++ b/dashtx.js
@@ -625,7 +625,7 @@ var DashTx = ("object" === typeof module && exports) || {};
       //@ts-ignore
       exports.nobleSecp256k1 || require("@dashincubator/secp256k1");
 
-    let sigOpts = { canonical: true };
+    let sigOpts = { canonical: true, extraEntropy: true };
     let sigBuf = await Secp256k1.sign(txHashBuf, privateKey, sigOpts);
     return sigBuf;
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dashtx",
-  "version": "0.9.0-3",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dashtx",
-      "version": "0.9.0-3",
+      "version": "0.9.0",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.9.0-3",
+  "version": "0.9.0",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "files": [


### PR DESCRIPTION
Current standard practice is to salt the signatures such that they end up different every time - even when signing the exact same bytes twice in a row.