### PR TITLE
fix: replace "units" with "satoshis" to prevent exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ let txInfo = {
   outputs: [
     {
       pubKeyHash: "1e0a6ef6085bb8af443a9e7f8941e61deb09fb54",
-      units: 5150,
+      satoshis: 5150,
     },
   ],
   locktime: 0,
@@ -139,7 +139,7 @@ let txInfo = {
     {
       // "XdRgbwH1LEfFQUVY2DnmsVxfo33CRDhydj"
       pubKeyHash: "1e0a6ef6085bb8af443a9e7f8941e61deb09fb54",
-      units: 5150,
+      satoshis: 5150,
     },
   ],
   locktime: 0,
@@ -175,7 +175,7 @@ console.info(txInfo.transaction);
   "outputs": [
     {
       "pubKeyHash": "1e0a6ef6085bb8af443a9e7f8941e61deb09fb54",
-      "units": 5150
+      "satoshis": 5150
     }
   ],
   "transaction": "030000...000000",


### PR DESCRIPTION
`units` is not the correct key, it seems. 

Fixes: 
```
/home/foobar/code/DashJoin.js/node_modules/dashtx/dashtx.js:461
        throw new Error(`every output must have 'satoshis'`);
              ^

Error: every output must have 'satoshis'
    at /home/foobar/code/DashJoin.js/node_modules/dashtx/dashtx.js:461:15
    at Array.forEach (<anonymous>)
    at Object.Tx._create (/home/foobar/code/DashJoin.js/node_modules/dashtx/dashtx.js:459:13)
    at Object.Tx.createHashable (/home/foobar/code/DashJoin.js/node_modules/dashtx/dashtx.js:351:18)
    at Object.Tx._hashAndSignAll (/home/foobar/code/DashJoin.js/node_modules/dashtx/dashtx.js:251:27)
    at Object.hashAndSignAll (/home/foobar/code/DashJoin.js/node_modules/dashtx/dashtx.js:144:23)
    at demo (/home/foobar/code/DashJoin.js/src/tx-dashcore-lib.js:50:29)
    at /home/foobar/code/DashJoin.js/src/tx-dashcore-lib.js:58:9
    at Object.<anonymous> (/home/foobar/code/DashJoin.js/src/tx-dashcore-lib.js:60:3)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
```
