### PR TITLE
fix(memo): correct byte lengths, output count, and support donation to the network

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ let Secp256k1 = require("@dashincubator/secp256k1");
 
 async function sign({ privateKey, hash }) {
   let sigOpts = { canonical: true, extraEntropy: true };
-  let sigBuf = await Secp256k1.sign(hash, privateKey, sigOpts);
-  return Tx.utils.u8ToHex(sigBuf);
+  let sigBytes = await Secp256k1.sign(hash, privateKey, sigOpts);
+  return Tx.utils.bytesToHex(sigBytes);
 }
 
 // ...
@@ -65,8 +65,8 @@ Note: You must provide your own `sign()` function, as shown below.
 
   async function sign({ privateKey, hash }) {
     let sigOpts = { canonical: true, extraEntropy: true };
-    let sigBuf = await Secp256k1.sign(hash, privateKey, sigOpts);
-    return Tx.utils.u8ToHex(sigBuf);
+    let sigBytes = await Secp256k1.sign(hash, privateKey, sigOpts);
+    return Tx.utils.bytesToHex(sigBytes);
   }
 
   // ...
@@ -90,7 +90,7 @@ let txInfo = {
       sigHashType: 0x01,
       script: "76a9145bcd...694488ac",
       getPrivateKey: function () {
-        return privateKeyBuf;
+        return privateKeyBytes;
       },
     },
   ],
@@ -120,7 +120,7 @@ console.info(txInfo.transaction);
 // "XJREPzkMSHobz6kpxKd7reMiWr3YoyTdaj3sJXLGCmiDHaL7vmaQ"
 let privateKeyHex =
   "d4c569f71ea2a9be6010cb3691f2757bc9539c60fd87e8bed21d7844d7b9b246";
-let privateKey = Tx.utils.hexToU8(privateKeyHex);
+let privateKey = Tx.utils.hexToBytes(privateKeyHex);
 
 let publicKeyHex =
   "03755be68d084e7ead4d83e23fb37c3076b16ead432de1b0bdf249290400f263cb";
@@ -296,12 +296,12 @@ Tx.utils.reverseHex(hex);
 /**
  * Convert a hex string to a Uint8Array
  */
-Tx.utils.hexToU8(hex);
+Tx.utils.hexToBytes(hex);
 
 /**
  * Convert a Uint8Array to a hex string
  */
-Tx.utils.u8ToHex(u8);
+Tx.utils.bytesToHex(bytes);
 ```
 
 #### You-do-It Functions
@@ -318,14 +318,14 @@ Tx.create({ sign });
  * We recommend @dashincubator/secp246k1 and @noble/secp246k1.
  *
  * @param {Uint8Array} privateKey - an input's corresponding key
- * @param {Uint8Array} txHashBuf - the (not reversed) 2x-sha256-hash
+ * @param {Uint8Array} txHashBytes - the (not reversed) 2x-sha256-hash
  * @returns {String} - hex representation of an ASN.1 signature
  */
-async function sign(privateKey, txHashBuf) {
+async function sign(privateKey, txHashBytes) {
   let sigOpts = { canonical: true };
-  let sigBuf = await Secp256k1.sign(txHashBuf, privateKey, sigOpts);
+  let sigBytes = await Secp256k1.sign(txHashBytes, privateKey, sigOpts);
 
-  return Tx.utils.u8ToHex(sigBuf);
+  return Tx.utils.bytesToHex(sigBytes);
 }
 ```
 

--- a/dashtx.js
+++ b/dashtx.js
@@ -41,8 +41,8 @@
  * @prop {TxToVarInt} toVarInt
  * @prop {TxToVarIntSize} toVarIntSize
  * @prop {TxReverseHex} reverseHex
- * @prop {TxHexToU8} hexToU8
- * @prop {TxU8ToHex} u8ToHex
+ * @prop {TxHexToBytes} hexToBytes
+ * @prop {TxBytesToHex} bytesToHex
  */
 
 /**
@@ -472,7 +472,7 @@ var DashTx = ("object" === typeof module && exports) || {};
           "oops, you gave a publicKey as hex (deprecated) rather than a buffer",
         );
         //@ts-ignore
-        pubKey = Tx.utils.hexToU8(pubKey);
+        pubKey = Tx.utils.hexToBytes(pubKey);
       }
       //@ts-ignore
       return pubKey;
@@ -532,7 +532,7 @@ var DashTx = ("object" === typeof module && exports) || {};
             "oops, you gave a publicKey as hex (deprecated) rather than a buffer",
           );
           //@ts-ignore
-          pubKey = Tx.utils.hexToU8(pubKey);
+          pubKey = Tx.utils.hexToBytes(pubKey);
         }
         return pubKey;
       };
@@ -549,7 +549,7 @@ var DashTx = ("object" === typeof module && exports) || {};
       let privKey = await myUtils.getPrivateKey(txInput, i, txInfo.inputs);
 
       let sigBuf = await myUtils.sign(privKey, txHashBuf);
-      let sigHex = Tx.utils.u8ToHex(sigBuf);
+      let sigHex = Tx.utils.bytesToHex(sigBuf);
       if ("string" === typeof sigBuf) {
         console.warn(`sign() should return a Uint8Array of an ASN.1 signature`);
         sigHex = sigBuf;
@@ -559,7 +559,7 @@ var DashTx = ("object" === typeof module && exports) || {};
       if (!pubKeyHex) {
         //@ts-ignore
         let pubKey = await myUtils.getPublicKey(txInput, i, txInfo.inputs);
-        pubKeyHex = Tx.utils.u8ToHex(pubKey);
+        pubKeyHex = Tx.utils.bytesToHex(pubKey);
       }
       if ("string" !== typeof pubKeyHex) {
         let warn = new Error("stack");
@@ -567,7 +567,7 @@ var DashTx = ("object" === typeof module && exports) || {};
           `utxo inputs should be plain JSON and use hex rather than buffers for 'publicKey'`,
           warn.stack,
         );
-        pubKeyHex = Tx.utils.u8ToHex(pubKeyHex);
+        pubKeyHex = Tx.utils.bytesToHex(pubKeyHex);
       }
 
       let txInputSigned = {
@@ -579,7 +579,7 @@ var DashTx = ("object" === typeof module && exports) || {};
       };
 
       // expose _actual_ values used, for debugging
-      let txHashHex = Tx.utils.u8ToHex(txHashBuf);
+      let txHashHex = Tx.utils.bytesToHex(txHashBuf);
       txInput._hash = txHashHex;
       txInput._signature = sigHex.toString();
       txInput._lockScript = txInfo.inputs[i].script;
@@ -824,7 +824,7 @@ var DashTx = ("object" === typeof module && exports) || {};
   };
 
   Tx.getId = async function (txHex) {
-    let u8 = Tx.utils.hexToU8(txHex);
+    let u8 = Tx.utils.hexToBytes(txHex);
     //console.log("Broadcastable Tx Buffer");
     //console.log(u8);
 
@@ -843,7 +843,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     //console.log("Reversed Round 2 Hash Buffer");
     //console.log(reverseU8);
 
-    let id = Tx.utils.u8ToHex(reverseU8);
+    let id = Tx.utils.bytesToHex(reverseU8);
     return id;
   };
 
@@ -856,7 +856,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     //console.log("Signable Tx Hex");
     //console.log(txSignable);
 
-    let u8 = Tx.utils.hexToU8(txSignable);
+    let u8 = Tx.utils.hexToBytes(txSignable);
     //console.log("Signable Tx Buffer");
     //console.log(u8);
 
@@ -926,7 +926,7 @@ var DashTx = ("object" === typeof module && exports) || {};
   /**
    * @param {String} hex
    */
-  TxUtils.hexToU8 = function (hex) {
+  TxUtils.hexToBytes = function (hex) {
     let bufLen = hex.length / 2;
     let u8 = new Uint8Array(bufLen);
 
@@ -948,6 +948,7 @@ var DashTx = ("object" === typeof module && exports) || {};
 
     return u8;
   };
+  TxUtils.hexToU8 = TxUtils.hexToBytes;
 
   /**
    * @param {String} hex
@@ -1108,7 +1109,7 @@ var DashTx = ("object" === typeof module && exports) || {};
    * @returns {String} hex
    */
   //@ts-ignore
-  TxUtils.u8ToHex = function (u8) {
+  TxUtils.bytesToHex = function (u8) {
     /** @type {Array<String>} */
     let hex = [];
 
@@ -1119,6 +1120,7 @@ var DashTx = ("object" === typeof module && exports) || {};
 
     return hex.join("");
   };
+  TxUtils.u8ToHex = TxUtils.bytesToHex;
 
   Tx.utils = TxUtils;
 })(globalThis.window || {}, DashTx);
@@ -1323,7 +1325,7 @@ if ("object" === typeof module) {
  */
 
 /**
- * @callback TxHexToU8
+ * @callback TxHexToBytes
  * @param {String} hex
  * @returns {Uint8Array}
  */
@@ -1407,7 +1409,7 @@ if ("object" === typeof module) {
  */
 
 /**
- * @callback TxU8ToHex
+ * @callback TxBytesToHex
  * @param {Uint8Array} buf
  * @returns {String}
  */

--- a/dashtx.js
+++ b/dashtx.js
@@ -508,6 +508,7 @@ var DashTx = ("object" === typeof module && exports) || {};
       inputs: [],
       outputs: txInfo.outputs,
       _DANGER_donate: txInfo._DANGER_donate,
+      _donation_memo: txInfo._donation_memo,
     };
 
     // temp shim
@@ -678,6 +679,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     /* maxFee = 10000, */
     _debug = false,
     _DANGER_donate = false,
+    _donation_memo,
   }) {
     let sep = "";
     if (_debug) {
@@ -766,6 +768,21 @@ var DashTx = ("object" === typeof module && exports) || {};
           `'outputs' list must not be empty - use the developer debug option '_DANGER_donate: true' to bypass`,
         );
       }
+
+      let memo = _donation_memo;
+      if (!memo) {
+        let encoder = new TextEncoder();
+        let gifts = ["💸", "🎁", "🧧"];
+        let indexIsh = Math.random() * 3;
+        let index = Math.floor(indexIsh);
+        let gift = encoder.encode(gifts[index]);
+        memo = TxUtils.bytesToHex(gift);
+      }
+
+      outputs.push({
+        satoshis: 0,
+        memo: memo,
+      });
     }
 
     let nOutputs = Tx.utils.toVarInt(outputs.length);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.11.0",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.11.0",
+      "version": "0.12.3",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"
@@ -29,9 +29,8 @@
     },
     "node_modules/zora": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/zora/-/zora-5.2.0.tgz",
-      "integrity": "sha512-FSZOvfJVfMWhk/poictNsDBCXq/Z+2Zu2peWs6d8OhWWb9nY++czw95D47hdw06L/kfjasLevwrbUtnXyWLAJw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.11.0",
+  "version": "0.12.3",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "files": [

--- a/tests/hash-and-sign-all.js
+++ b/tests/hash-and-sign-all.js
@@ -106,7 +106,7 @@ Zora.test("reproduce known rawtx", async function (t) {
   await tx
     .hashAndSignAll(txInfo /*, keys*/)
     .then(function (txInfoSigned) {
-      t.equal(rawtx, txInfoSigned.transaction);
+      t.equal(txInfoSigned.transaction, rawtx);
     })
     .catch(function (err) {
       t.ok(false, err.message);

--- a/tests/legacy-tx.js
+++ b/tests/legacy-tx.js
@@ -1,7 +1,8 @@
 "use strict";
 
 let Zora = require("zora");
-let DashTx = require("../");
+
+let DashTx = require("../dashtx.js");
 
 let outputs = [
   {

--- a/tests/lex-sort.js
+++ b/tests/lex-sort.js
@@ -2,6 +2,8 @@
 
 let Zora = require("zora");
 
+let DashTx = require("../dashtx.js");
+
 function unsort(sorted) {
   let unsorted = [];
   let copy = sorted.slice(0);
@@ -97,8 +99,6 @@ let outputsSorted = [
     script: "76a9a0",
   },
 ];
-
-let DashTx = require("../");
 
 function testSort(sorter, sorted) {
   let copy = sorted.slice(0);

--- a/tests/memo.js
+++ b/tests/memo.js
@@ -1,0 +1,105 @@
+"use strict";
+
+let Zora = require("zora");
+
+let Secp256k1 = require("@dashincubator/secp256k1");
+
+let DashTx = require("../dashtx.js");
+let dashTx = DashTx.create({
+  sign: async function (privateKey, hash) {
+    let sigOpts = {
+      canonical: true,
+      // ONLY FOR TESTING: use deterministic signature (rather than random)
+      extraEntropy: null,
+    };
+    let sigBuf = await Secp256k1.sign(hash, privateKey, sigOpts);
+    return sigBuf;
+  },
+});
+
+Zora.test("memo lengths", function (t) {
+  let memo1 = "ff";
+  let memo75 = "ee".repeat(75);
+  let memo76 = "dd".repeat(76);
+  let memo77 = "cc".repeat(77);
+  let memo80 = "bb".repeat(80);
+  let memo81 = "aa".repeat(81);
+
+  let size1 = "01";
+  let size3 = "03";
+  let size75 = "4b";
+  let size76 = "4c";
+  let size77 = "4d";
+  //let size78 = "4e";
+  let size79 = "4f";
+  let size80 = "50";
+  //let size81 = "51";
+  //let size82 = "52";
+  let size83 = "53";
+
+  let OP_PD1 = "4c";
+
+  t.throws(
+    function () {
+      DashTx._createMemoScript(memo81);
+    },
+    /\b80 bytes\b/,
+    "memo > 80 bytes should throw an error",
+  );
+
+  let tx1 = DashTx._createMemoScript(memo1);
+  let tx1a = `0000000000000000${size3}6a${size1}${memo1}`;
+  let tx1b = tx1.join("");
+  t.deepEqual(tx1b, tx1a, "single-byte memo fits");
+
+  let tx75 = DashTx._createMemoScript(memo75);
+  let tx75a = `0000000000000000${size77}6a${size75}${memo75}`;
+  let tx75b = tx75.join("");
+  t.deepEqual(tx75b, tx75a, "75-byte memo fits");
+
+  let tx76a = `0000000000000000${size79}6a${OP_PD1}${size76}${memo76}`;
+  let tx76 = DashTx._createMemoScript(memo76);
+  let tx76b = tx76.join("");
+  t.deepEqual(tx76b, tx76a, "76-byte memo fits with OP_PUSHDATA1");
+
+  let tx77a = `0000000000000000${size80}6a${OP_PD1}${size77}${memo77}`;
+  let tx77 = DashTx._createMemoScript(memo77);
+  let tx77b = tx77.join("");
+  t.deepEqual(tx77b, tx77a, "77-byte memo fits with OP_PUSHDATA1");
+
+  let tx80a = `0000000000000000${size83}6a${OP_PD1}${size80}${memo80}`;
+  let tx80 = DashTx._createMemoScript(memo80);
+  let tx80b = tx80.join("");
+  t.deepEqual(tx80b, tx80a, "80-byte memo fits with OP_PUSHDATA1");
+});
+
+Zora.test("can create memo tx", async function (t) {
+  let privKeyHex =
+    "ba0863ae0c162d67ae68a7f1e9dfdb7e3c47a71d397e19d7442f1afef3928511";
+  let pkh = "82754a9c935fbfcdda5995a32006a68a8156ee2b";
+
+  let txId = "77".repeat(32);
+  let coins = [
+    { pubKeyHash: pkh, satoshis: 20000, txId: txId, outputIndex: 0 },
+  ];
+
+  /** @type {Array<DashTx.TxOutput>} */
+  let outputs = [];
+
+  let encoder = new TextEncoder();
+  let memoBytes = encoder.encode("Hello, Dash!");
+  let memoHex = DashTx.utils.bytesToHex(memoBytes);
+  outputs.push({ memo: memoHex, satoshis: 0 });
+
+  let changeOutput = { pubKeyHash: pkh };
+  let txInfo = await DashTx.legacyCreateTx(coins, outputs, changeOutput);
+
+  let privKey = DashTx.utils.hexToBytes(privKeyHex);
+  let keys = [privKey];
+  let txInfoSigned = await dashTx.hashAndSignAll(txInfo, keys);
+
+  let rawtx =
+    "03000000017777777777777777777777777777777777777777777777777777777777777777000000006a4730440220404c24dd8fff16b226c4795093b49e1060039c687120a9aaeca65cf321c593e00220180b160b3b2e937f9f5b9a8658a55c7511926b4631c421813c659e4f22b29140012103f808bdec4293bf12441ec9a9e61bc3b264c78fcc5ad499ce5f0799f2874e6856ffffffff0200000000000000000e6a0c48656c6c6f2c204461736821484d0000000000001976a91482754a9c935fbfcdda5995a32006a68a8156ee2b88ac00000000";
+
+  t.equal(txInfoSigned.transaction, rawtx, "created transaction with memo");
+});

--- a/tests/memo.js
+++ b/tests/memo.js
@@ -103,3 +103,40 @@ Zora.test("can create memo tx", async function (t) {
 
   t.equal(txInfoSigned.transaction, rawtx, "created transaction with memo");
 });
+
+Zora.test("can create donation tx via memo", async function (t) {
+  let privKeyHex =
+    "ba0863ae0c162d67ae68a7f1e9dfdb7e3c47a71d397e19d7442f1afef3928511";
+  let pkh = "82754a9c935fbfcdda5995a32006a68a8156ee2b";
+
+  let txId = "77".repeat(32);
+  let inputs = [
+    { pubKeyHash: pkh, satoshis: 20000, txId: txId, outputIndex: 0 },
+  ];
+
+  /** @type {Array<DashTx.TxOutput>} */
+  let outputs = [];
+
+  let encoder = new TextEncoder();
+  //let memoBytes = encoder.encode("💸");
+  //let memoBytes = encoder.encode("🎁");
+  let memoBytes = encoder.encode("🧧");
+  let memo = DashTx.utils.bytesToHex(memoBytes);
+
+  let txInfo = {
+    inputs: inputs,
+    outputs: outputs,
+    _DANGER_donate: true,
+    _donation_memo: memo,
+  };
+
+  let privKey = DashTx.utils.hexToBytes(privKeyHex);
+  let keys = [privKey];
+  let txInfoSigned = await dashTx.hashAndSignAll(txInfo, keys);
+  let txHex = txInfoSigned.transaction;
+
+  let rawtx =
+    "03000000017777777777777777777777777777777777777777777777777777777777777777000000006b483045022100d2a13920c4002ee76df3cd3a0afcebb12e71871c63bb49ba379de6d709f488b60220627252f66903c3dfa69ba86a581c09342721a15d75e2a455a2dff09187e7668e012103f808bdec4293bf12441ec9a9e61bc3b264c78fcc5ad499ce5f0799f2874e6856ffffffff010000000000000000066a04f09fa7a700000000";
+
+  t.equal(txHex, rawtx, "created donation transaction via memo");
+});


### PR DESCRIPTION
Well, that was dumb.

I mean, I did fix a bug, but the maximum memo length only went up from 75 bytes to 80 bytes so... 🤷‍♀️

(it didn't actually support 83 bytes - that number includes the opcode and size bytes)