### PR TITLE
doc+ref: document createLegacyTx() and add signOpts.getPrivateKey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "files": [


### PR DESCRIPTION
Due to the nature of sorting inputs and outputs, the `keys` array will need to be deprecated and replaced with a local `getPrivateKey()` option.

The reason we don't allow private keys directly on the `input` object is that  they've very likely to be logged when debugging, etc, and we don't want the keys showing up in the logs.

```diff
-  let keys = [addressKey.privateKey];
-  let txInfoSigned = await dashTx.hashAndSignAll(txInfo, keys);
+  let signOpts = {
+    getPrivateKey: function (input, i) {
+      // look up a private key by the address, pubKeyHash, or pubkey of input
+      return addressKey.privateKey;
+    },
+  };
+  let txInfoSigned = await dashTx.hashAndSignAll(txInfo, signOpts);
```