### PR TITLE
add `version` to `txInfoSigned`

### DIFF
--- a/dashtx.js
+++ b/dashtx.js
@@ -541,6 +541,7 @@ var DashTx = ("object" === typeof module && exports) || {};
       /** @type {Array<TxInputHashable|TxInputSigned>} */
       inputs: [],
       outputs: txInfo.outputs,
+      version: txInfo.version,
       _DANGER_donate: txInfo._DANGER_donate,
       _donation_memo: txInfo._donation_memo,
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "files": [


### PR DESCRIPTION
`createSigned` inside of `Tx._hashAndSignAll` was not passing the version provided in the `txInfo` param and therefor could not adjust the version.

This is required if wanting to use DashTx.js with other cryptocurrencies.