### PR TITLE
Fix bundlephobia and esm import

### DIFF
--- a/dashtx.mjs
+++ b/dashtx.mjs
@@ -1,3 +1,6 @@
+// Based on discoveries from
+// https://github.com/jojobyte/browser-import-rabbit-hole
+
 import './dashtx.js'
 import * as DashTxTypes from './dashtx.js'
 

--- a/dashtx.mjs
+++ b/dashtx.mjs
@@ -1,0 +1,7 @@
+import './dashtx.js'
+import * as DashTxTypes from './dashtx.js'
+
+/** @type {DashTxTypes} */
+let DashTx = window?.DashTx || globalThis?.DashTx
+
+export default DashTx

--- a/package.json
+++ b/package.json
@@ -2,14 +2,21 @@
   "name": "dashtx",
   "version": "0.14.4",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
-  "main": "index.js",
+  "main": "dashtx.js",
+  "module": "dashtx.mjs",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "require": "./dashtx.js",
+      "import": "./dashtx.mjs",
+      "default": "./dashtx.js"
+    }
+  },
   "files": [
-    "index.js",
     "dashtx.js",
-    "./lib/"
+    "dashtx.mjs"
   ],
   "browser": {
-    "index.js": "dashtx.js",
     "crypto": false
   },
   "bin": {


### PR DESCRIPTION
Inspecting https://bundlephobia.com/package/dashtx@0.14.1 (and 0.14.0) results in an EntryPointError, this resolves the EntryPointError issue as well as some issues with using the package as an ESM module.

See https://bundlephobia.com/package/dashtx@0.14.2-1 for this code working at bundlephobia.