### PR TITLE
fix: scope keyUtils to hashAndSignAll lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.14.1",
+      "version": "0.14.3",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.14.1",
+  "version": "0.14.3",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
reverts 7e870a484bf7af1c6db6d2f30fd55fadb7c0c19b (published in v0.14.0)

`hashAndSignAll()`, which has multiple async handoffs, needs its own, scoped copy of the key utils so that when it is called concurrently, each call gets its own, correct key-map function. 

This time more explicit - and a comment - so that I don't pull a stupid like that again.