### PR TITLE
ref: ditch confusing dependency injection (corrected)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,6 @@ Tx.hashPartial(txHex, Tx.SIGHASH_ALL);
 
 // Deprecated
 Tx.createLegacyTx(coins, outputs, changeOutput);
-Tx.utils.hexToU8 // Tx.utils.hexToBytes;
-Tx.utils.u8ToHex // Tx.utils.bytesToHex;
 
 // Not API-locked, May change
 Tx.utils.sign(privKeyBytes, txHashBytes);

--- a/README.md
+++ b/README.md
@@ -26,60 +26,167 @@ Server and browser compatible. Vanilla JS. 0 Dependencies.
 npm install --save @dashincubator/secp256k1
 npm install --save dashkeys
 npm install --save dashtx
+npm install --save dashkeys
 ```
 
-Note: You may provide your own `sign()` function, as shown below.
+Note: You must provide your own _Key Util_ functions, as shown below.
 
 ```js
 "use strict";
 
-let Tx = require("dashtx");
-let tx = Tx.create({ sign: sign });
-
+let DashKeys = require("dashkeys");
+let DashTx = require("dashtx");
 let Secp256k1 = require("@dashincubator/secp256k1");
 
-async function sign(privKeyBytes, hashBytes) {
-  let sigOpts = { canonical: true, extraEntropy: true };
-  let sigBytes = await Secp256k1.sign(hashBytes, privKeyBytes, sigOpts);
-  return sigBytes;
-}
+let yourWalletKeyDataMapGoesHere = {
+  /* SEE BELOW */
+};
 
-// ...
+let keyUtils = {
+  /* SEE BELOW */
+};
+let dashTx = DashTx.create(keyUtils);
+
+let inputs = [{ outputIndex, publicKey, txid /*, optional addr/pkh/hdpath */ }];
+let outputs = [{ satoshis, pubKeyHash /*, optional addr/hdpath/etc */ }];
+let txInfo = { inputs, outputs };
+
+// Sorted as per "Lexicographical Indexing of Transaction Inputs and Outputs"
+txInfo.inputs.sort(DashTx.sortInputs);
+txInfo.outputs.sort(DashTx.sortOutputs);
+
+let txInfoSigned = await dashTx.hashAndSignAll(txInfo);
+
+console.info(JSON.stringify(txInfo, null, 2));
+console.info(txInfo.transaction);
 ```
 
 ## Browsers
 
 ```html
 <script src="https://unpkg.com/@dashincubator/secp256k1/secp256k1.js"></script>
+<script src="https://unpkg.com/dashkeys/dashkeys.js"></script>
 <script src="https://unpkg.com/dashtx/dashtx.js"></script>
 ```
 
-Note: You must provide your own `sign()` function, as shown below.
+Note: You must provide your own _Key Util_ functions, as shown below.
 
 ```js
-(function () {
+(async function () {
   "use strict";
 
-  let Tx = window.DashTx;
-  let tx = Tx.create({ sign: sign });
-
+  let DashKeys = window.DashTx;
+  let DashTx = window.DashKeys;
   let Secp256k1 = window.nobleSecp256k1;
 
-  async function sign(privKeyBytes, hashBytes) {
-    let sigOpts = { canonical: true, extraEntropy: true };
-    let sigBytes = await Secp256k1.sign(hashBytes, privKeyBytes, sigOpts);
-    return sigBytes;
-  }
+  let yourWalletKeyDataMapGoesHere = {
+    /* SEE BELOW */
+  };
+
+  let keyUtils = {
+    /* SEE BELOW */
+  };
+  let dashTx = DashTx.create(keyUtils);
+
+  let inputs = [
+    { outputIndex, publicKey, txid /*, optional addr/pkh/hdpath */ },
+  ];
+  let outputs = [{ satoshis, pubKeyHash /*, optional addr/hdpath/etc */ }];
+  let txInfo = { inputs, outputs };
+
+  // Sorted as per "Lexicographical Indexing of Transaction Inputs and Outputs"
+  txInfo.inputs.sort(DashTx.sortInputs);
+  txInfo.outputs.sort(DashTx.sortOutputs);
+
+  let txInfoSigned = await dashTx.hashAndSignAll(txInfo);
+
+  console.info(JSON.stringify(txInfo, null, 2));
+  console.info(txInfo.transaction);
 
   // ...
 })();
 ```
 
-## Example Usage
+## Example Wallet Key Data
+
+DashTx does not depend on any specific implementation of a wallet key storage
+engine, but it works great with plain-old JSON:
+
+```js
+let yourWalletKeyMapGoesHere = {
+  yTw3SFk9PbQ1kikMgJBRA7CFyLfNt2G6QD: {
+    hdpath: "0bGYi3S7n2Q|m/44'/1'/0'/0/0",
+    address: "yTw3SFk9PbQ1kikMgJBRA7CFyLfNt2G6QD",
+    wif: "cUeUEgRQWfKiYPBeRZsYsrvvSZiKHbUNqiQE2AdKA4s7ymycdVxc",
+  },
+  yb4zn8MSW4hHsvmP6PxX2tUPDb9bvmxSrS: {
+    hdpath: "0bGYi3S7n2Q|m/44'/1'/0'/0/1",
+    wif: "cN28SZpmmuVFmmBQBHCNdwa6a14kWZM8VVpZETjzk47aGNvVGXK7",
+    address: "yb4zn8MSW4hHsvmP6PxX2tUPDb9bvmxSrS",
+  },
+  yfrB4v4cih7os6t1tg4YuWkrTYmHyMHkZb: {
+    hdpath: "0bGYi3S7n2Q|m/44'/1'/0'/0/2",
+    address: "yfrB4v4cih7os6t1tg4YuWkrTYmHyMHkZb",
+    wif: "cQBHjCxspabNZKGMK3gbuvSLgssqSxAuDsaMMDuzgXioYyR723Bg",
+  },
+  // ...
+};
+```
+
+You can use any indexing, query, or storage strategy you like, with values in
+Base58Check, Hex, Byte, or whatever else you fancy - just as long as your
+provided _Key Util_ functions can convert them.
+
+## Example Key Utils
+
+DashTx does not depend on any specific implementation of signing or key
+transformation, but it works greeat **NobleSecp256k1** and **DashKeys**:
+
+```text
+getPrivateKey(txInput, i)
+getPublicKey(txInput, i)
+sign(privKeyBytes, txHashBytes)
+toPublicKey(privKeyBytes)
+```
+
+```js
+let keyUtils = {
+  getPrivateKey: async function (txInput, i) {
+    let pkhBytes = DashKeys.utils.hexToBytes(txInput.pubKeyHash);
+    let address = await DashKeys.pkhToAddr(txInput.pubKeyHash);
+
+    let yourKeyData = yourWalletKeyMapGoesHere[address];
+
+    let privKeyBytes = DashKeys.wifToPrivKey(yourKeyData.wif);
+    return privKeyBytes;
+  },
+
+  getPublicKey: async function (txInput, i) {
+    let privKeyBytes = getPrivateKey(txInput, i);
+    let pubKeyBytes = await keyUtils.toPublicKey(privKeyBytes);
+
+    return pubKeyBytes;
+  },
+
+  sign: async function (privKeyBytes, txHashBytes) {
+    let sigOpts = { canonical: true, extraEntropy: true };
+    let sigBytes = await Secp256k1.sign(txHashBytes, privKeyBytes, sigOpts);
+
+    return sigBytes;
+  },
+
+  toPublicKey: async function (privKeyBytes) {
+    let isCompressed = true;
+    let pubKeyBytes = Secp256k1.getPublicKey(privateKey, isCompressed);
+
+    return pubKeyBytes;
+  },
+};
+```
+
+## Example Tx Info
 
 See also: [example.js](/example.js).
-
-Note: You must provide your own `sign()` function, as shown above.
 
 ```js
 let memo = Tx.utils.strToHex("Hello, Dash!");
@@ -114,7 +221,6 @@ let txInfo = {
 txInfo.inputs.sort(Tx.sortInputs);
 txInfo.outputs.sort(Tx.sortOutputs);
 
-let keys = txInfo.inputs.map(getPrivateKey);
 let txInfoSigned = await tx.hashAndSignAll(txInfo);
 
 console.info(JSON.stringify(txInfo, null, 2));
@@ -160,7 +266,6 @@ let txInfo = {
 txInfo.inputs.sort(Tx.sortInputs);
 txInfo.outputs.sort(Tx.sortOutputs);
 
-let keys = txInfo.inputs.map(getPrivateKey);
 let txInfoSigned = await tx.hashAndSignAll(txInfo);
 
 console.info(JSON.stringify(txInfo, null, 2));
@@ -278,7 +383,7 @@ Tx.OUTPUT_SIZE         //          34
 ```
 
 ```text
-Tx.create({ sign, getPrivateKey });
+Tx.create({ getPrivateKey, getPublicKey, sign, toPublicKey });
     tx.hashAndSignAll(txInfo);
     tx.legacy.draftSingleOutput({ utxos, inputs, output });
     tx.legacy.finalizePresorted(txDraft, keys);
@@ -304,18 +409,13 @@ Tx.hashPartial(txHex, Tx.SIGHASH_ALL);
 
 // Deprecated
 Tx.createLegacyTx(coins, outputs, changeOutput);
-
-// Not API-locked, May change
-Tx.utils.sign(privKeyBytes, txHashBytes);
-Tx.utils.toPublicKey(privKeyBytes);
-Tx.utils.addrToPubKeyHash(addr);
 ```
 
 ```js
 /**
  * Creates a tx signer instance.
  */
-Tx.create({ sign, getPrivateKey });
+Tx.create({ getPrivateKey, getPublicKey, sign, toPublicKey });
 
 /**
  * Estimates the min, mid, and max sizes of (fees for) a transaction (including memos).
@@ -469,26 +569,7 @@ Tx.utils.strToHex(str);
 ### You-do-It Functions
 
 ```js
-Tx.create({ sign, getPrivateKey });
-
-/**
- * Sign a 256-bit hash. 'canonical' form is required for
- * blockchains. Must return the signature as an ASN.1 DER.
- * These may or may not be the default options, depending
- * on the library used.
- *
- * We recommend @dashincubator/secp256k1 and @noble/secp256k1.
- *
- * @param {Uint8Array} privateKey - an input's corresponding key
- * @param {Uint8Array} txHashBytes - the (not reversed) 2x-sha256-hash
- * @returns {String} - hex representation of an ASN.1 signature
- */
-async function sign(privateKey, txHashBytes) {
-  let sigOpts = { canonical: true };
-  let sigBytes = await Secp256k1.sign(txHashBytes, privateKey, sigOpts);
-
-  return Tx.utils.bytesToHex(sigBytes);
-}
+Tx.create({ getPrivateKey, getPublicKey, sign, toPublicKey });
 
 /**
  * Given information that you provided about an input
@@ -504,10 +585,47 @@ async function sign(privateKey, txHashBytes) {
  * @returns {Uint8Array} - the private key bytes
  */
 async function getPrivateKey(txInput, i) {
-  let address = await DashKeys.pubkeyToAddr(txInput.publicKey);
-  let privateKey = privateKeys[address];
+  let pkhBytes = DashKeys.utils.hexToBytes(txInput.pubKeyHash);
+  let address = await DashKeys.pkhToAddr(txInput.pubKeyHash);
+  let privKeyBytes = privateKeys[address];
 
-  return privateKey;
+  return privKeyBytes;
+}
+
+async function getPublicKey(txInput, i) {
+  let privKeyBytes = getPrivateKey(txInput, i);
+  let publicKey = await toPublicKey(privKeyBytes);
+
+  return publicKey;
+}
+
+let Secp256k1 =
+  //@ts-ignore
+  window.nobleSecp256k1 || require("@dashincubator/secp256k1");
+
+/**
+ * Sign a 256-bit hash. 'canonical' form is required for
+ * blockchains. Must return the signature as an ASN.1 DER.
+ * These may or may not be the default options, depending
+ * on the library used.
+ *
+ * We recommend @dashincubator/secp256k1 and @noble/secp256k1.
+ *
+ * @param {Uint8Array} privateKey - an input's corresponding key
+ * @param {Uint8Array} txHashBytes - the (not reversed) 2x-sha256-hash
+ * @returns {String} - hex representation of an ASN.1 signature
+ */
+async function sign(privKeyBytes, txHashBytes) {
+  let sigOpts = { canonical: true, extraEntropy: true };
+  let sigBytes = await Secp256k1.sign(txHashBytes, privKeyBytes, sigOpts);
+
+  return sigBytes;
+}
+
+async function toPublicKey(privKeyBytes) {
+  let isCompressed = true;
+  let pubKeyBytes = Secp256k1.getPublicKey(privateKey, isCompressed);
+  return pubKeyBytes;
 }
 ```
 

--- a/examples/tx.test.js
+++ b/examples/tx.test.js
@@ -43,14 +43,14 @@ Secp256k1.utils.hmacSha256 = async function (key, message) {
 /* jshint maxstatements: 200 */
 async function main() {
   //let expectedBytes = "00ff0ff0fff00f00";
-  //let u8 = Tx.utils.hexToU8("00ff0ff0fff00f00");
+  //let u8 = Tx.utils.hexToBytes("00ff0ff0fff00f00");
   //console.log(u8);
 
   let isCompressed = true;
   let sigHashType = 0x01;
 
   //let rndPrivKey = Secp256k1.utils.randomPrivateKey();
-  //console.log("Random Private Key", Tx.utils.u8ToHex(rndPrivKey));
+  //console.log("Random Private Key", Tx.utils.bytesToHex(rndPrivKey));
 
   let btcRawTxIn = {
     version: 1,
@@ -85,21 +85,21 @@ async function main() {
   let btcTxHashBuf = await Tx.hashPartial(btcSignableTxHex, sigHashType);
   console.log();
   console.log("Signable BTC Tx Hash");
-  console.log(Tx.utils.u8ToHex(btcTxHashBuf));
+  console.log(Tx.utils.bytesToHex(btcTxHashBuf));
   console.log();
 
   // From https://bitcointalk.org/index.php?topic=651344.0
   // cSf2Lcme2kSpkZ1s5AW8a2K2Y41P8HYGoXAevNzPUna6iXDw9boC
   let btcPrivKeyHex =
     "976917491dd96b045af13e5cf5dd81013682974f20c8a78de9f7873bb39620e8";
-  let privKeyU8 = Tx.utils.hexToU8(btcPrivKeyHex);
-  //console.log("pk", Tx.utils.u8ToHex(privKey));
+  let privKeyU8 = Tx.utils.hexToBytes(btcPrivKeyHex);
+  //console.log("pk", Tx.utils.bytesToHex(privKey));
   let btcSig = await Secp256k1.sign(btcTxHashBuf, privKeyU8, {
     canonical: false,
   });
   let btcPub = Secp256k1.getPublicKey(privKeyU8, isCompressed);
-  let btcSigHex = Tx.utils.u8ToHex(btcSig);
-  let btcPubHex = Tx.utils.u8ToHex(btcPub);
+  let btcSigHex = Tx.utils.bytesToHex(btcSig);
+  let btcPubHex = Tx.utils.bytesToHex(btcPub);
 
   console.log("Signature");
   console.log(btcSigHex);
@@ -198,16 +198,16 @@ async function main() {
   console.log();
   console.log("Magic Signable Tx Hashes");
   for (let dashTxHashBuf of dashTxHashBufs) {
-    console.log(Tx.utils.u8ToHex(dashTxHashBuf));
+    console.log(Tx.utils.bytesToHex(dashTxHashBuf));
   }
   console.log();
 
   // TODO output u8 instead of hex
   let privKeyHex =
     "d4c569f71ea2a9be6010cb3691f2757bc9539c60fd87e8bed21d7844d7b9b246";
-  let privKey = Tx.utils.hexToU8(privKeyHex);
+  let privKey = Tx.utils.hexToBytes(privKeyHex);
   console.log(privKey);
-  //console.log("pk", Tx.utils.u8ToHex(privKey));
+  //console.log("pk", Tx.utils.bytesToHex(privKey));
 
   /** @typedef {import('./tx.js').TxInputHashable} TxInputHashable */
   /** @typedef {import('./tx.js').TxInputSigned} TxInputSigned */
@@ -224,11 +224,11 @@ async function main() {
 
     let sig = await Secp256k1.sign(dashTxHashBuf, privKey, { canonical: true });
     let pub = Secp256k1.getPublicKey(privKey, isCompressed);
-    let dashSigHex = Tx.utils.u8ToHex(sig);
-    let dashPubHex = Tx.utils.u8ToHex(pub);
+    let dashSigHex = Tx.utils.bytesToHex(sig);
+    let dashPubHex = Tx.utils.bytesToHex(pub);
 
     console.log(`Tx Hash [${i}]`);
-    console.log(Tx.utils.u8ToHex(dashTxHashBuf));
+    console.log(Tx.utils.bytesToHex(dashTxHashBuf));
     console.log(`Signature [${i}]`);
     console.log(dashSigHex);
     console.log(`Public Key [${i}]`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.14.5",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.14.5",
+      "version": "0.15.0",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/dashhive/dashtx.js#readme",
   "devDependencies": {
     "@dashincubator/secp256k1": "^1.7.1-5",
-    "@types/node": "^20.12.7",
+    "@types/node": "^20.11.30",
     "dashkeys": "^1.1.0",
     "zora": "^5.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.14.5",
+  "version": "0.15.0",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "module": "dashtx.mjs",

--- a/tests/hash-and-sign-all.js
+++ b/tests/hash-and-sign-all.js
@@ -75,7 +75,7 @@ let txInfo = {
 
 Zora.test("reproduce known rawtx", async function (t) {
   let keysMap = {};
-  keysMap[prevLockScript] = Tx.utils.hexToU8(privKeyHex);
+  keysMap[prevLockScript] = Tx.utils.hexToBytes(privKeyHex);
 
   let tx = Tx.create({
     sign: async function (privateKey, hash) {

--- a/tests/memo.js
+++ b/tests/memo.js
@@ -3,17 +3,21 @@
 let Zora = require("zora");
 
 let Secp256k1 = require("@dashincubator/secp256k1");
+let DashKeys = require("dashkeys");
 
 let DashTx = require("../dashtx.js");
 let dashTx = DashTx.create({
-  sign: async function (privateKey, hash) {
+  sign: async function (privKeyBytes, hashBytes) {
     let sigOpts = {
       canonical: true,
       // ONLY FOR TESTING: use deterministic signature (rather than random)
       extraEntropy: null,
     };
-    let sigBuf = await Secp256k1.sign(hash, privateKey, sigOpts);
+    let sigBuf = await Secp256k1.sign(hashBytes, privKeyBytes, sigOpts);
     return sigBuf;
+  },
+  toPublicKey: async function (privKeyBytes) {
+    return DashKeys.utils.toPublicKey(privKeyBytes);
   },
 });
 


### PR DESCRIPTION
replaces #47, which was closed by mistake

## Preview

https://github.com/dashhive/DashTx.js/tree/ref-false-deps

## Why?

This has caused issues with false positive missing dependency warnings in bundlers, and it's just confusing to look at.

Nixing.

Although this reduces convenience, DashTx isn't meant to be convenient - it's meant to be accurate. Wallet libraries built atop DashTx will make it convenient.