### PR TITLE
ref! only support `getPrivateKey()`, drop `keys` array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.15.3",
+      "version": "0.16.0",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.15.3",
+  "version": "0.16.0",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "module": "dashtx.mjs",

--- a/tests/memo.js
+++ b/tests/memo.js
@@ -3,7 +3,6 @@
 let Zora = require("zora");
 
 let Secp256k1 = require("@dashincubator/secp256k1");
-let DashKeys = require("dashkeys");
 
 let DashTx = require("../dashtx.js");
 let dashTx = DashTx.create({
@@ -17,7 +16,15 @@ let dashTx = DashTx.create({
     return sigBuf;
   },
   toPublicKey: async function (privKeyBytes) {
-    return DashKeys.utils.toPublicKey(privKeyBytes);
+    let isCompressed = true;
+    let pubKeyBuf = Secp256k1.getPublicKey(privKeyBytes, isCompressed);
+    return pubKeyBuf;
+  },
+  getPrivateKey: async function (txInput) {
+    let privKeyHex =
+      "ba0863ae0c162d67ae68a7f1e9dfdb7e3c47a71d397e19d7442f1afef3928511";
+    let privKeyBytes = DashTx.utils.hexToBytes(privKeyHex);
+    return privKeyBytes;
   },
 });
 
@@ -78,8 +85,6 @@ Zora.test("memo lengths", function (t) {
 });
 
 Zora.test("can create memo tx", async function (t) {
-  let privKeyHex =
-    "ba0863ae0c162d67ae68a7f1e9dfdb7e3c47a71d397e19d7442f1afef3928511";
   let pkh = "82754a9c935fbfcdda5995a32006a68a8156ee2b";
 
   let txId = "77".repeat(32);
@@ -98,9 +103,7 @@ Zora.test("can create memo tx", async function (t) {
   let changeOutput = { pubKeyHash: pkh };
   let txInfo = await DashTx.legacyCreateTx(coins, outputs, changeOutput);
 
-  let privKey = DashTx.utils.hexToBytes(privKeyHex);
-  let keys = [privKey];
-  let txInfoSigned = await dashTx.hashAndSignAll(txInfo, keys);
+  let txInfoSigned = await dashTx.hashAndSignAll(txInfo);
 
   let rawtx =
     "03000000017777777777777777777777777777777777777777777777777777777777777777000000006b483045022100888db2ea9388e2c29d2480fd3374250cb2242a7dfa0e4bc6d82ac01b58f99dfb02200fe878c74f58eebf234f31a43a17bc6ea1535de6f7f2329ac007107888a39199012103f808bdec4293bf12441ec9a9e61bc3b264c78fcc5ad499ce5f0799f2874e6856ffffffff0200000000000000000e6a0c48656c6c6f2c204461736821484d0000000000001976a91482754a9c935fbfcdda5995a32006a68a8156ee2b88ac00000000";
@@ -109,8 +112,6 @@ Zora.test("can create memo tx", async function (t) {
 });
 
 Zora.test("can create donation tx via memo", async function (t) {
-  let privKeyHex =
-    "ba0863ae0c162d67ae68a7f1e9dfdb7e3c47a71d397e19d7442f1afef3928511";
   let pkh = "82754a9c935fbfcdda5995a32006a68a8156ee2b";
 
   let txId = "77".repeat(32);
@@ -127,9 +128,7 @@ Zora.test("can create donation tx via memo", async function (t) {
     outputs: outputs,
   };
 
-  let privKey = DashTx.utils.hexToBytes(privKeyHex);
-  let keys = [privKey];
-  let txInfoSigned = await dashTx.hashAndSignAll(txInfo, keys);
+  let txInfoSigned = await dashTx.hashAndSignAll(txInfo);
   let txHex = txInfoSigned.transaction;
 
   let rawtx =


### PR DESCRIPTION
In the simplest case, having a `keys` array rather than a `getPrivateKey()` method _seems_ more convenient.

However, beyond any simple test case, trying to track the order of the `keys` array becomes obnoxious and error prone.

The goal for DashTx is not to be a n00b-friendly tx library (no such thing can exist), but it is to make developing wallets easy - and the `getPrivateKey()` function does _much_ better at that.