### PR TITLE
fix: use ?. to check if keyUtils.getPrivateKey exists

### DIFF
--- a/dashtx.js
+++ b/dashtx.js
@@ -250,7 +250,7 @@ var DashTx = ("object" === typeof module && exports) || {};
   };
 
   Tx.create = function (keyUtils) {
-    if (!keyUtils.getPrivateKey) {
+    if (!keyUtils?.getPrivateKey) {
       throw new Error(`you must create with 'opts.getPrivateKey()'`);
     }
 


### PR DESCRIPTION
Fixes #72. `keyUtils.getPrivateKey` => `keyUtils?.getPrivateKey`