### PR TITLE
WIP: feat: add `pubkeyToPkh` and `addrToPkh` to `keyUtils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ let keyUtils = {
 
     return pubKeyBytes;
   },
+
+  pubkeyToPkh: DashKeys.pubkeyToPkh,
+
+  addrToPkh: DashKeys.addrToPkh,
 };
 ```
 


### PR DESCRIPTION
## Overview

We have a few conflicting concerns:
- we want devs to be able to interop with other cryptocurrency libraries
- we don't want hard dependencies on our own where there's a clear separation of concerns
- providing in-code, no-dep defaults causes some sites and bundlers, like bundlephobia, to fail
- `getaddressutxos` is unreliable \
   https://github.com/dashpay/dash/issues/6215
- `getaddressdeltas` and `getaddressmempool` are reliable, but are missing `script` \
   https://github.com/dashpay/dash/issues/6215

To solve this we can do any of:
- leave more tedium to the developer (current)
- add new convenience methods to `keyUtils` (proposed)
- create a hard dependency on DashKeys (reasonable, but not prefered)

## The Cumbersome Code

In particular, going from the tx draft to the tx final + signed requires a bit more ceremony than I'd like:

```js
        let draftTx = dashTx.legacy.draftSingleOutput({ utxos, inputs, output });
        console.log('DEBUG draftTx', draftTx);

        // See https://github.com/dashhive/DashTx.js/pull/77
        for (let input of draftTx.inputs) {
            let addressInfo = keysMap[input.address];
            Object.assign(input, {
                publicKey: addressInfo.publicKey,
                pubKeyHash: addressInfo.pubKeyHash,
            });
        }
        for (let output of draftTx.outputs) {
            if (output.pubKeyHash) {
                continue;
            }
            if (!output.address) {
                throw new Error(`output is missing 'address' and 'pubKeyHash'`);
            }
            let pkhBytes = await DashKeys.addrToPkh(output.address, {
                version: 'mainnet',
            });
            Object.assign(output, {
                pubKeyHash: DashKeys.utils.bytesToHex(pkhBytes),
            });
        }

        draftTx.inputs.sort(DashTx.sortInputs);
        draftTx.outputs.sort(DashTx.sortOutputs);
```