### PR TITLE
feat: include DashTx.utils.rpc(basicAuthUrl, method, arg1, arg2, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ Tx.appraise({ inputs, outputs });
 
 Tx.parseUnknown(serializedHex);
 
+// RPC, for 'sendrawtransaction' broadcast
+Tx.utils.rpc(basicAuthUrl, method, arg1, arg2, ...);
+
 // Byte-level helpers
 Tx.utils.toVarInt(n);
 Tx.utils.toVarIntSize(n);
@@ -571,6 +574,19 @@ Tx.doubleSha256(txBytes);
  * ready-to-broadcast transaction with signed inputs.
  */
 Tx.parseUnknown(serializedHex);
+```
+
+### RPC Helper
+
+```js
+/**
+ * Make RPC calls to a web service, masternode, or full node
+ *
+ * ex:
+ *   - https://api:token@rpc.digitalcash.dev/
+ *   - http://user:pass@localhost:19998/wallet/foo
+ */
+Tx.utils.rpc(basicAuthUrl, method, arg1, arg2, ...);
 ```
 
 ### Utility Functions

--- a/dashtx.js
+++ b/dashtx.js
@@ -1692,6 +1692,40 @@ var DashTx = ("object" === typeof module && exports) || {};
   }
 
   /**
+   * @param {String} basicAuthUrl - ex: https://api:token@trpc.digitalcash.dev/
+   *                                    http://user:pass@localhost:19998/
+   * @param {String} method - the rpc, such as 'getblockchaininfo',
+   *                          'getaddressdeltas', or 'help'
+   * @param {...any} params - the arguments for the specific rpc
+   *                          ex: rpc(url, 'help', 'getaddressdeltas')
+   */
+  TxUtils.rpc = async function rpc(basicAuthUrl, method, ...params) {
+    let url = new URL(basicAuthUrl);
+    let baseUrl = `${url.protocol}//${url.host}${url.pathname}`;
+    let basicAuth = btoa(`${url.username}:${url.password}`);
+
+    // typically http://localhost:19998/
+    let payload = JSON.stringify({ method, params });
+    let resp = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basicAuth}`,
+        "Content-Type": "application/json",
+      },
+      body: payload,
+    });
+
+    let data = await resp.json();
+    if (data.error) {
+      let err = new Error(data.error.message);
+      Object.assign(err, data.error);
+      throw err;
+    }
+
+    return data.result;
+  };
+
+  /**
    * @param {String} hex
    */
   TxUtils.hexToBytes = function (hex) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.18.3",
+      "version": "0.18.4",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "module": "dashtx.mjs",

--- a/tests/rpc-getblockchaininfo.js
+++ b/tests/rpc-getblockchaininfo.js
@@ -1,0 +1,11 @@
+"use strict";
+
+let Zora = require("zora");
+
+let DashTx = require("../dashtx.js");
+
+Zora.test("rpc 'getblockchaininfo'", async function (t) {
+  let rpcUrl = "https://user:null@trpc.digitalcash.dev/";
+  let info = await DashTx.utils.rpc(rpcUrl, "getblockchaininfo");
+  t.equal(info.chain, "test", `trpc 'chain' should be 'test'`);
+});


### PR DESCRIPTION
No need for insight, DashSight, dashd-rpc, or DashRPC.js.

This is the real deal, right here.