### PR TITLE
fix: remove leftover 'async' marker from tx drafting function [READ]

### DIFF
--- a/dashtx.js
+++ b/dashtx.js
@@ -687,7 +687,7 @@ var DashTx = ("object" === typeof module && exports) || {};
    * or the largest available coins until that total is met.
    */
   //@ts-ignore - TODO update typedefs
-  Tx.createLegacyTx = async function (coins, outputs, changeOutput) {
+  Tx.createLegacyTx = function (coins, outputs, changeOutput) {
     // TODO bump to 4 for DIP: enforce tx hygiene
     let version = CURRENT_VERSION;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "module": "dashtx.mjs",

--- a/tests/legacy-tx.js
+++ b/tests/legacy-tx.js
@@ -13,27 +13,26 @@ let outputs = [
 
 let changeOutput = {};
 
-Zora.test("too few sats", async function (t) {
+Zora.test("too few sats", function (t) {
   let inputs = [
     {
       satoshis: 20000 + 190,
     },
   ];
-  await DashTx.legacyCreateTx(inputs, outputs, changeOutput)
-    .then(function () {
-      t.ok(false, "should throw when there aren't enough sats");
-    })
-    .catch(function (e) {
-      let msg = e.message;
-      let isAboutMemo = /\bcannot pay for\b/.test(e.message);
-      if (isAboutMemo) {
-        msg = "throws when there are too few sats";
-      }
-      t.ok(isAboutMemo, msg);
-    });
+  try {
+    DashTx.legacyCreateTx(inputs, outputs, changeOutput);
+    t.ok(false, "should throw when there aren't enough sats");
+  } catch (e) {
+    let msg = e.message;
+    let isAboutMemo = /\bcannot pay for\b/.test(e.message);
+    if (isAboutMemo) {
+      msg = "throws when there are too few sats";
+    }
+    t.ok(isAboutMemo, msg);
+  }
 });
 
-Zora.test("exactly enough sats", async function (t) {
+Zora.test("exactly enough sats", function (t) {
   let inputs = [
     {
       satoshis: 20000 + 190,
@@ -43,52 +42,37 @@ Zora.test("exactly enough sats", async function (t) {
     },
   ];
 
-  await DashTx.legacyCreateTx(inputs, outputs, changeOutput)
-    .then(function () {
-      t.ok(true, "sats match exactly");
-    })
-    .catch(function (e) {
-      t.ok(false, e.message);
-    });
+  DashTx.legacyCreateTx(inputs, outputs, changeOutput);
+  t.ok(true, "sats match exactly");
 });
 
-Zora.test("donates dust", async function (t) {
+Zora.test("donates dust", function (t) {
   let satoshis = 20000 + 193 + DashTx.LEGACY_DUST + DashTx.OUTPUT_SIZE + -1;
   let inputs = [{ satoshis }];
 
-  await DashTx.legacyCreateTx(inputs, outputs, changeOutput)
-    .then(function (txInfo) {
-      if (txInfo.length > 1) {
-        throw new Error("created return change for dust");
-      }
-      t.ok(true, "has no return change");
-    })
-    .catch(function (e) {
-      t.ok(false, e.message);
-    });
+  let txInfo = DashTx.legacyCreateTx(inputs, outputs, changeOutput);
+  if (txInfo.length > 1) {
+    throw new Error("created return change for dust");
+  }
+  t.ok(true, "has no return change");
 });
 
-Zora.test("returns change", async function (t) {
+Zora.test("returns change", function (t) {
   let satoshis = 20000 + 193 + DashTx.LEGACY_DUST + DashTx.OUTPUT_SIZE;
   let inputs = [{ satoshis }];
 
-  await DashTx.legacyCreateTx(inputs, outputs, changeOutput)
-    .then(function (txInfo) {
-      let hasChange = txInfo.changeIndex >= 0;
-      if (!hasChange) {
-        throw new Error("did not create return change");
-      }
+  let txInfo = DashTx.legacyCreateTx(inputs, outputs, changeOutput);
+  let hasChange = txInfo.changeIndex >= 0;
+  if (!hasChange) {
+    throw new Error("did not create return change");
+  }
 
-      let change = txInfo.outputs[txInfo.changeIndex];
-      if (!change) {
-        throw new Error("did not add change to outputs");
-      }
+  let change = txInfo.outputs[txInfo.changeIndex];
+  if (!change) {
+    throw new Error("did not add change to outputs");
+  }
 
-      t.ok(true, "returned change >= dust");
-    })
-    .catch(function (e) {
-      t.ok(false, e.message);
-    });
+  t.ok(true, "returned change >= dust");
 });
 
 Zora.test("coins selection is better than random", async function (t) {
@@ -100,21 +84,16 @@ Zora.test("coins selection is better than random", async function (t) {
     { satoshis: 500000 },
   ];
 
-  await DashTx.legacyCreateTx(inputs, outputs, changeOutput)
-    .then(function (txInfo) {
-      let tooManyInputs = txInfo.inputs.length >= 0;
-      if (!tooManyInputs) {
-        throw new Error("selected more inputs than necessary");
-      }
+  let txInfo = await DashTx.legacyCreateTx(inputs, outputs, changeOutput);
+  let tooManyInputs = txInfo.inputs.length >= 0;
+  if (!tooManyInputs) {
+    throw new Error("selected more inputs than necessary");
+  }
 
-      let isOptimalInput = txInfo.inputs[0].satoshis === exact;
-      if (!isOptimalInput) {
-        throw new Error("did not select clearly optimal input");
-      }
+  let isOptimalInput = txInfo.inputs[0].satoshis === exact;
+  if (!isOptimalInput) {
+    throw new Error("did not select clearly optimal input");
+  }
 
-      t.ok(true, "selected closest input");
-    })
-    .catch(function (e) {
-      t.ok(false, e.message);
-    });
+  t.ok(true, "selected closest input");
 });

--- a/tests/lex-sort.js
+++ b/tests/lex-sort.js
@@ -179,12 +179,7 @@ Zora.test("legacyCreateTx uses lex sort functions", async function (t) {
 
   let changeOutput = {};
 
-  await DashTx.legacyCreateTx(inputs, outputs, changeOutput)
-    .then(function (txInfo) {
-      t.deepEqual(sortedIn, txInfo.inputs, "inputs should be sorted");
-      t.deepEqual(sortedOut, txInfo.outputs, "outputs should be sorted");
-    })
-    .catch(function (e) {
-      t.ok(false, e.message);
-    });
+  let txInfo = DashTx.legacyCreateTx(inputs, outputs, changeOutput);
+  t.deepEqual(sortedIn, txInfo.inputs, "inputs should be sorted");
+  t.deepEqual(sortedOut, txInfo.outputs, "outputs should be sorted");
 });


### PR DESCRIPTION
Related to some of what was reviewed here: https://www.youtube.com/watch?v=7TBHmndBx00

It's actually _IMPORTANT_ for the the drafting functions to NOT be `async` - it helps prevent duplicate spend issues and general state management issues (i.e. another process could request the same address).

Here's another summary of the tx lifecycle:

1. _sync_ draftTx
2. (??) reserveFundsInWallet
3. backfill & await signTx
4. await broadcastTx
5. (??) commitWalletState

We want the loop between the draft and the reserve to be as close as possible so that other tasks can't use them, and without having to depend on storage and sync implementation details of the wallet.