### PR TITLE
feat(platform): split 'version' from 'type', add 'extraPayload', new utils exports

### DIFF
--- a/dashtx.js
+++ b/dashtx.js
@@ -63,6 +63,8 @@
  * @prop {TxHexToBytes} hexToBytes
  * @prop {TxBytesToHex} bytesToHex
  * @prop {TxStringToHex} strToHex
+ * @prop {TxToUint32LE} toUint32LE
+ * @prop {TxToUint64LE} toUint64LE
  */
 
 /**
@@ -1160,7 +1162,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     void Tx.serializeInputs(inputs, { _tx: tx, _sep: _sep });
     void Tx.serializeOutputs(outputs, { _tx: tx, _sep: _sep });
 
-    let locktimeHex = TxUtils._toUint32LE(locktime);
+    let locktimeHex = TxUtils.toUint32LE(locktime);
     tx.push(locktimeHex);
 
     if (extraPayload) {
@@ -1170,7 +1172,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     }
 
     if (sigHashType) {
-      let sigHashTypeHex = TxUtils._toUint32LE(sigHashType);
+      let sigHashTypeHex = TxUtils.toUint32LE(sigHashType);
       tx.push(sigHashTypeHex);
     }
 
@@ -1221,7 +1223,7 @@ var DashTx = ("object" === typeof module && exports) || {};
         `expected utxo property 'input[${i}]outputIndex' to be an integer representing this input's previous output index`,
       );
     }
-    let reverseVout = TxUtils._toUint32LE(voutIndex);
+    let reverseVout = TxUtils.toUint32LE(voutIndex);
     tx.push(reverseVout);
 
     //@ts-ignore - enum types not handled properly here
@@ -1309,7 +1311,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     if (!output.satoshis) {
       throw new Error(`every output must have 'satoshis'`);
     }
-    let satoshis = TxUtils._toUint64LE(output.satoshis);
+    let satoshis = TxUtils.toUint64LE(output.satoshis);
     tx.push(satoshis);
 
     if (!output.pubKeyHash) {
@@ -1348,7 +1350,7 @@ var DashTx = ("object" === typeof module && exports) || {};
    */
   Tx._createMemoScript = function (memoHex, sats, i = 0) {
     let outputHex = [];
-    let satoshis = TxUtils._toUint64LE(sats);
+    let satoshis = TxUtils.toUint64LE(sats);
     outputHex.push(satoshis);
 
     assertHex(memoHex, `output[${i}].memo`);
@@ -1816,17 +1818,17 @@ var DashTx = ("object" === typeof module && exports) || {};
 
     //@ts-ignore
     if (n <= MAX_U16) {
-      return "fd" + TxUtils._toUint32LE(n).slice(0, 4);
+      return "fd" + TxUtils.toUint32LE(n).slice(0, 4);
     }
 
     //@ts-ignore
     if (n <= MAX_U32) {
-      return "fe" + TxUtils._toUint32LE(n);
+      return "fe" + TxUtils.toUint32LE(n);
     }
 
     //@ts-ignore
     if (n <= MAX_U53) {
-      return "ff" + TxUtils._toUint64LE(n);
+      return "ff" + TxUtils.toUint64LE(n);
     }
 
     if ("bigint" !== typeof n) {
@@ -1836,7 +1838,7 @@ var DashTx = ("object" === typeof module && exports) || {};
     }
 
     if (n <= MAX_U64) {
-      return "ff" + TxUtils._toUint64LE(n);
+      return "ff" + TxUtils.toUint64LE(n);
     }
 
     let err = new Error(E_TOO_BIG_INT);
@@ -1850,7 +1852,7 @@ var DashTx = ("object" === typeof module && exports) || {};
    * @param {BigInt|Number} n - 16-bit positive int to encode
    */
   TxUtils._toUint16LE = function (n) {
-    let hexLE = TxUtils._toUint32LE(n);
+    let hexLE = TxUtils.toUint32LE(n);
     // ex: 03000800 => 0300
     hexLE = hexLE.slice(0, 4);
     return hexLE;
@@ -1861,7 +1863,7 @@ var DashTx = ("object" === typeof module && exports) || {};
    * which is true in practice, and much simpler.
    * @param {BigInt|Number} n - 32-bit positive int to encode
    */
-  TxUtils._toUint32LE = function (n) {
+  TxUtils.toUint32LE = function (n) {
     // make sure n is uint32/int53, not int32
     //n = n >>> 0;
 
@@ -1871,6 +1873,13 @@ var DashTx = ("object" === typeof module && exports) || {};
     let hexLE = Tx.utils.reverseHex(hex);
     return hexLE;
   };
+  //@ts-ignore
+  TxUtils._toUint32LE = function (n) {
+    console.warn(
+      "warn: use public TxUtils.toUint32LE() instead of internal TxUtils._toUint32LE()",
+    );
+    return TxUtils.toUint32LE(n);
+  };
 
   /**
    * This can handle Big-Endian CPUs, which don't exist,
@@ -1878,7 +1887,7 @@ var DashTx = ("object" === typeof module && exports) || {};
    * @param {BigInt|Number} n - 64-bit BigInt or <= 53-bit Number to encode
    * @returns {String} - 8 Little-Endian bytes
    */
-  TxUtils._toUint64LE = function (n) {
+  TxUtils.toUint64LE = function (n) {
     let bn;
     if ("bigint" === typeof n) {
       bn = n;
@@ -1902,6 +1911,13 @@ var DashTx = ("object" === typeof module && exports) || {};
     let hex = hexArr.join("");
 
     return hex;
+  };
+  //@ts-ignore
+  TxUtils._toUint64LE = function (n) {
+    console.warn(
+      "warn: use public TxUtils.toUint64LE() instead of internal TxUtils._toUint64LE()",
+    );
+    return TxUtils.toUint64LE(n);
   };
 
   /** @type TxToVarIntSize */
@@ -2455,4 +2471,16 @@ if ("object" === typeof module) {
  * @callback TxStringToHex
  * @param {String} utf8
  * @returns {String} - encoded bytes as hex
+ */
+
+/**
+ * @callback TxToUint32LE
+ * @param {Uint32} n
+ * @returns {Hex}
+ */
+
+/**
+ * @callback TxToUint64LE
+ * @param {Uint32} n
+ * @returns {Hex}
  */

--- a/dashtx.js
+++ b/dashtx.js
@@ -24,6 +24,7 @@
  * @prop {TxCreateInputRaw} createInputRaw
  * @prop {TxCreateForSig} createForSig
  * @prop {TxCreateInputForSig} createInputForSig
+ * @prop {TxCreatePkhScript} createPkhScript
  * @prop {TxCreateSigned} createSigned
  * @prop {TxGetId} getId - only useful for fully signed tx
  * @prop {TxCreateLegacyTx} createLegacyTx
@@ -1122,7 +1123,7 @@ var DashTx = ("object" === typeof module && exports) || {};
           `signable input must have either 'pubKeyHash' or 'script'`,
         );
       }
-      lockScript = `${OP_DUP}${OP_HASH160}${PKH_SIZE}${input.pubKeyHash}${OP_EQUALVERIFY}${OP_CHECKSIG}`;
+      lockScript = Tx.createPkhScript(input.pubKeyHash);
     }
     return {
       txId: input.txId || input.txid,
@@ -1132,6 +1133,15 @@ var DashTx = ("object" === typeof module && exports) || {};
       sigHashType: input.sigHashType,
       script: lockScript,
     };
+  };
+
+  /**
+   * @param {Hex} pubKeyHash
+   * @returns {Hex}
+   */
+  Tx.createPkhScript = function (pubKeyHash) {
+    let lockScript = `${OP_DUP}${OP_HASH160}${PKH_SIZE}${pubKeyHash}${OP_EQUALVERIFY}${OP_CHECKSIG}`;
+    return lockScript;
   };
 
   Tx.serialize = function (
@@ -2193,6 +2203,12 @@ if ("object" === typeof module) {
  * @callback TxCreateInputForSig
  * @param {TxInputForSig} input
  * @param {Uint32} inputIndex - create hashable tx for this input
+ */
+
+/**
+ * @callback TxCreatePkhScript
+ * @param {Hex} pubKeyHash
+ * @returns {Hex} - ${OP_DUP}${OP_HASH160}${PKH_SIZE}${pubKeyHash}${OP_EQUALVERIFY}${OP_CHECKSIG}
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashtx",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashtx",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "module": "dashtx.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashtx",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Create DASH Transactions with Vanilla JS (0 deps, cross-platform)",
   "main": "dashtx.js",
   "module": "dashtx.mjs",

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -11,11 +11,17 @@ async function test() {
     let filename = "dsf.tx-request.hex";
     let txInfo = await parseHexFile(filename);
 
-    if (txInfo.versionHex !== "02000000") {
-      throw new Error(`${filename} versionHex is not 02000000`);
+    if (txInfo.versionHex !== "0200") {
+      throw new Error(`${filename} versionHex is not 0200`);
     }
     if (txInfo.version !== 2) {
       throw new Error(`${filename} version is not 2`);
+    }
+    if (txInfo.typeHex !== "0000") {
+      throw new Error(`${filename} typeHex is not 0000`);
+    }
+    if (txInfo.type !== 0) {
+      throw new Error(`${filename} type is not 0`);
     }
 
     if (txInfo.inputs.length !== 18) {
@@ -36,6 +42,10 @@ async function test() {
       throw new Error(`${filename} locktime is not 0`);
     }
 
+    if (txInfo.extraPayloadHex !== "") {
+      throw new Error(`${filename} extraPayloadHex is not '' (empty string)`);
+    }
+
     if (txInfo.sigHashTypeHex) {
       throw new Error(`${filename} should not have sigHashTypeHex`);
     }
@@ -48,11 +58,17 @@ async function test() {
     let filename = "dss.tx-response.hex";
     let txInfo = await parseHexFile(filename);
 
-    if (txInfo.versionHex !== "02000000") {
-      throw new Error(`${filename} versionHex is not 02000000`);
+    if (txInfo.versionHex !== "0200") {
+      throw new Error(`${filename} versionHex is not 0200`);
     }
     if (txInfo.version !== 2) {
       throw new Error(`${filename} version is not 2`);
+    }
+    if (txInfo.typeHex !== "0000") {
+      throw new Error(`${filename} typeHex is not 0000`);
+    }
+    if (txInfo.type !== 0) {
+      throw new Error(`${filename} type is not 0`);
     }
 
     if (txInfo.inputs.length !== 2) {
@@ -71,6 +87,10 @@ async function test() {
       throw new Error(
         `${filename} locktime is not 2004296226: ${txInfo.locktime}`,
       );
+    }
+
+    if (txInfo.extraPayloadHex !== "") {
+      throw new Error(`${filename} extraPayload is not '' (empty string)`);
     }
   }
 
@@ -107,11 +127,17 @@ async function test() {
     let filename = "sighash-all.tx.hex";
     let txInfo = await parseHexFile(filename);
 
-    if (txInfo.versionHex !== "02000000") {
-      throw new Error(`${filename} versionHex is not 02000000`);
+    if (txInfo.versionHex !== "0200") {
+      throw new Error(`${filename} versionHex is not 0200`);
     }
     if (txInfo.version !== 2) {
       throw new Error(`${filename} version is not 2`);
+    }
+    if (txInfo.typeHex !== "0000") {
+      throw new Error(`${filename} typeHex is not 0000`);
+    }
+    if (txInfo.type !== 0) {
+      throw new Error(`${filename} type is not 0`);
     }
 
     let scriptIndex = -1;
@@ -158,11 +184,17 @@ async function test() {
     let filename = "sighash-any.tx.hex";
     let txInfo = await parseHexFile(filename);
 
-    if (txInfo.versionHex !== "02000000") {
-      throw new Error(`${filename} versionHex is not 02000000`);
+    if (txInfo.versionHex !== "0200") {
+      throw new Error(`${filename} versionHex is not 0200`);
     }
     if (txInfo.version !== 2) {
       throw new Error(`${filename} version is not 2`);
+    }
+    if (txInfo.typeHex !== "0000") {
+      throw new Error(`${filename} typeHex is not 0000`);
+    }
+    if (txInfo.type !== 0) {
+      throw new Error(`${filename} type is not 0`);
     }
 
     let scriptIndex = -1;


### PR DESCRIPTION
We need to be able to create Platform TXes. Re: <https://github.com/dashhive/DashPlatform.js/issues/1>

Now we only use 2 bytes for `version`, and the other two for `type`.

We also allow a 'trailer' for AssetLock and AssetUnlock.

Tests updated.